### PR TITLE
Use explicit flags for parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ testdata:
 	go install
 	@export PATH=$$PATH:$$(go env GOPATH)/bin; \
 	cd testdata && protoc -I . \
-	--grpc-gateway-ts_out=logtostderr=true:./ \
+	--grpc-gateway-ts_out ./ \
+	--grpc-gateway-ts_opt logtostderr=true \
 	log.proto environment.proto ./datasource/datasource.proto
 
 .PHONY: lint

--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ You will need to install `protoc-gen-grpc-gateway-ts` before it could be picked 
 ### Sample Usage:
 `protoc-gen-grpc-gateway-ts` should be used along with the `protoc` command. A sample invocation looks like the following:
 
-`protoc --grpc-gateway-ts_out=ts_import_roots=$(pwd),ts_import_root_aliases=base:. input.proto`
+```bash
+protoc --grpc-gateway-ts_out . \
+  --grpc-gateway-ts_opt ts_import_roots=$(pwd) \
+  --grpc-gateway-ts_opt ts_import_root_aliases=base \
+  input.proto
+```
 
 As a result the generated file will be `input.pb.ts` in the same directory.
 
@@ -125,7 +130,8 @@ You should then pass `emit_unpopulated` as a parameter to the typescript plugin:
 ```bash
   protoc \
   ... \
-  --grpc-gateway-ts_out=emit_unpopulated=true:./ \
+  --grpc-gateway-ts_out ./ \
+  --grpc-gateway-ts_opt emit_unpopulated=true \
   ...
 ```
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -24,27 +24,10 @@ type TypeScriptGRPCGatewayGenerator struct {
 	EnableStylingCheck bool
 }
 
-const (
-	// EnableStylingCheckOption is the option name for EnableStylingCheck
-	EnableStylingCheckOption = "enable_styling_check"
-)
-
 // New returns an initialised generator
-func New(paramsMap map[string]string) (*TypeScriptGRPCGatewayGenerator, error) {
-	registry, err := registry.NewRegistry(paramsMap)
-	if err != nil {
-		return nil, errors.Wrap(err, "error instantiating a new registry")
-	}
-
-	enableStylingCheck := false
-	enableStylingCheckVal, ok := paramsMap[EnableStylingCheckOption]
-	if ok {
-		// default to true if not disabled specifi
-		enableStylingCheck = enableStylingCheckVal == "true"
-	}
-
+func New(reg *registry.Registry, enableStylingCheck bool) (*TypeScriptGRPCGatewayGenerator, error) {
 	return &TypeScriptGRPCGatewayGenerator{
-		Registry:           registry,
+		Registry:           reg,
 		EnableStylingCheck: enableStylingCheck,
 	}, nil
 }

--- a/integration_tests/scripts/gen-protos.sh
+++ b/integration_tests/scripts/gen-protos.sh
@@ -8,5 +8,10 @@ PATH=$GOBIN:$PATH
 
 cd .. && go install && cd integration_tests && \
 	protoc -I .  -I ../.. \
-	--grpc-gateway-ts_out=logtostderr=true,use_proto_names=$USE_PROTO_NAMES,emit_unpopulated=$EMIT_UNPOPULATED,enable_styling_check=$ENABLE_STYLING_CHECK,loglevel=debug:./ \
+	--grpc-gateway-ts_out ./ \
+	--grpc-gateway-ts_opt logtostderr=true \
+	--grpc-gateway-ts_opt loglevel=debug \
+	--grpc-gateway-ts_opt use_proto_names=$USE_PROTO_NAMES \
+	--grpc-gateway-ts_opt emit_unpopulated=$EMIT_UNPOPULATED \
+	--grpc-gateway-ts_opt enable_styling_check=$ENABLE_STYLING_CHECK \
 	service.proto msg.proto empty.proto

--- a/main.go
+++ b/main.go
@@ -1,21 +1,121 @@
 package main
 
 import (
-	"io/ioutil"
+	"flag"
+	"fmt"
+	"io"
 	"os"
 	"strings"
 
 	"github.com/dpup/protoc-gen-grpc-gateway-ts/generator"
+	"github.com/dpup/protoc-gen-grpc-gateway-ts/registry"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus" // nolint: depguard
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
+func main() {
+	if err := run(); err != nil {
+		panic(err)
+	}
+}
+
+func run() error {
+	var useProtoNames = flag.Bool("use_proto_names", false, "field names will match the protofile instead of lowerCamelCase")
+	var emitUnpopulated = flag.Bool("emit_unpopulated", false, "expect the gRPC Gateway to send zero values over the wire")
+	var fetchModuleDirectory = flag.String("fetch_module_directory", ".", "where shared typescript file should be placed, default $(pwd)")
+	var fetchModuleFilename = flag.String("fetch_module_filename", "fetch.pb.ts", "name of shard typescript file")
+	var tsImportRoots = flag.String("ts_import_roots", "", "defaults to $(pwd)")
+	var tsImportRootAliases = flag.String("ts_import_root_aliases", "", "use import aliases instead of relative paths")
+
+	var enableStylingCheck = flag.Bool("enable_styling_check", false, "TODO")
+
+	var logtostderr = flag.Bool("logtostderr", false, "turn on logging to stderr")
+	var loglevel = flag.String("loglevel", "info", "defines the logging level. Values are debug, info, warn, error")
+
+	flag.Parse()
+
+	req := decodeReq()
+	paramsMap := getParamsMap(req)
+	for k, v := range paramsMap {
+		if err := flag.CommandLine.Set(k, v); err != nil {
+			return fmt.Errorf("error setting flag %s: %w", k, err)
+		}
+	}
+
+	if err := configureLogging(*logtostderr, *loglevel); err != nil {
+		return err
+	}
+
+	reg, err := registry.NewRegistry(registry.Options{
+		UseProtoNames:        *useProtoNames,
+		EmitUnpopulated:      *emitUnpopulated,
+		FetchModuleDirectory: *fetchModuleDirectory,
+		FetchModuleFileName:  *fetchModuleFilename,
+		TSImportRoots:        *tsImportRoots,
+		TSImportRootAliases:  *tsImportRootAliases,
+	})
+	if err != nil {
+		return fmt.Errorf("error instantiating a new registry: %w", err)
+	}
+
+	g, err := generator.New(reg, *enableStylingCheck)
+	if err != nil {
+		return fmt.Errorf("error instantiating a new generator: %w", err)
+	}
+	log.Debug("Starts generating file request")
+	resp, err := g.Generate(req)
+	if err != nil {
+		return fmt.Errorf("error generating output: %w", err)
+	}
+	features := uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
+	resp.SupportedFeatures = &features
+
+	encodeResponse(resp)
+	log.Debug("generation finished")
+
+	return nil
+}
+
+func configureLogging(enableLogging bool, levelStr string) error {
+	if enableLogging {
+		log.SetFormatter(&log.TextFormatter{
+			DisableTimestamp: true,
+		})
+		log.SetOutput(os.Stderr)
+		log.Debugf("Logging configured completed, logging has been enabled")
+		if levelStr != "" {
+			level, err := log.ParseLevel(levelStr)
+			if err != nil {
+				return fmt.Errorf("error parsing log level %s: %s", levelStr, err)
+			}
+			log.SetLevel(level)
+		} else {
+			log.SetLevel(log.InfoLevel)
+		}
+	}
+	return nil
+}
+
+func getParamsMap(req *plugin.CodeGeneratorRequest) map[string]string {
+	paramsMap := make(map[string]string)
+	params := req.GetParameter()
+
+	for _, p := range strings.Split(params, ",") {
+		if i := strings.Index(p, "="); i < 0 {
+			paramsMap[p] = ""
+		} else {
+			paramsMap[p[0:i]] = p[i+1:]
+		}
+	}
+
+	return paramsMap
+}
+
 func decodeReq() *plugin.CodeGeneratorRequest {
 	req := &plugin.CodeGeneratorRequest{}
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		panic(err)
 	}
@@ -35,67 +135,4 @@ func encodeResponse(resp proto.Message) {
 	if err != nil {
 		panic(err)
 	}
-}
-
-func main() {
-	req := decodeReq()
-	paramsMap := getParamsMap(req)
-	err := configureLogging(paramsMap)
-	if err != nil {
-		panic(err)
-	}
-
-	g, err := generator.New(paramsMap)
-	if err != nil {
-		panic(err)
-	}
-
-	log.Debug("Starts generating file request")
-	resp, err := g.Generate(req)
-	if err != nil {
-		panic(err)
-	}
-	features := uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
-	resp.SupportedFeatures = &features
-
-	encodeResponse(resp)
-	log.Debug("generation finished")
-}
-
-func configureLogging(paramsMap map[string]string) error {
-	if paramsMap["logtostderr"] == "true" { // configure logging when it's in the options
-		log.SetFormatter(&log.TextFormatter{
-			DisableTimestamp: true,
-		})
-		log.SetOutput(os.Stderr)
-		log.Debugf("Logging configured completed, logging has been enabled")
-		levelStr := paramsMap["loglevel"]
-		if levelStr != "" {
-			level, err := log.ParseLevel(levelStr)
-			if err != nil {
-				return errors.Wrapf(err, "error parsing log level %s", levelStr)
-			}
-
-			log.SetLevel(level)
-		} else {
-			log.SetLevel(log.InfoLevel)
-		}
-	}
-
-	return nil
-}
-
-func getParamsMap(req *plugin.CodeGeneratorRequest) map[string]string {
-	paramsMap := make(map[string]string)
-	params := req.GetParameter()
-
-	for _, p := range strings.Split(params, ",") {
-		if i := strings.Index(p, "="); i < 0 {
-			paramsMap[p] = ""
-		} else {
-			paramsMap[p[0:i]] = p[i+1:]
-		}
-	}
-
-	return paramsMap
 }

--- a/testdata/log.proto
+++ b/testdata/log.proto
@@ -1,6 +1,7 @@
 syntax = 'proto3';
 
 package com.squareup.cash.gap;
+
 import "environment.proto";
 import "datasource/datasource.proto";
 


### PR DESCRIPTION
Hello,

THis is a new attempt at cleaning up how parameters are passed.

Please review the following commits I made in branch dan/options:

c2c2459a73f67781f58b5c2f859e5945a2445aac (2024-04-25 19:39:01 -0700)
Use explicit flags for parameters

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics