### PR TITLE
Use field_name?: field_type for optional fields, instead of OneOf extension, see #5

### DIFF
--- a/data/message.go
+++ b/data/message.go
@@ -14,6 +14,8 @@ type Message struct {
 	Fields []*Field
 	// NonOneOfFields contains a subset of fields that are not in the one-of groups
 	NonOneOfFields []*Field
+	// OptionalFields contains a subset of fields that are optional
+	OptionalFields []*Field
 	// Message is the nested messages defined inside the message
 	Messages []*Message
 	// OneOfFieldsGroups is the grouped list of one of fields with same index. so that renderer can render the clearing of other fields on set.

--- a/generator/template.go
+++ b/generator/template.go
@@ -37,6 +37,9 @@ type Base{{.Name}} = {
 {{- range .NonOneOfFields}}
   {{tsTypeKey .}}: {{tsTypeDef .}}
 {{- end}}
+{{- range .OptionalFields}}
+  {{tsTypeKey .}}: {{tsTypeDef .}}
+{{- end}}
 }
 
 export type {{.Name}} = Base{{.Name}}
@@ -541,9 +544,10 @@ func include(t *template.Template) func(name string, data interface{}) (string, 
 func tsTypeKey(r *registry.Registry) func(field *data.Field) string {
 	return func(field *data.Field) string {
 		name := fieldName(r)(field.Name)
-		if !r.EmitUnpopulated {
+		if !r.EmitUnpopulated || field.IsOptional {
 			// When EmitUnpopulated is false, the gateway will return undefined for
-			// any zero value, so all fields may be undefined.
+			// any zero value, so all fields may be undefined. Optional fields, may
+			// also be undefined if unset.
 			return name + "?"
 		}
 		// When it is false, only optional fields can be undefined, however they are

--- a/registry/field.go
+++ b/registry/field.go
@@ -74,6 +74,9 @@ func (r *Registry) analyseField(fileData *data.File, msgData *data.Message, pack
 	if !fieldData.IsOneOfField {
 		msgData.NonOneOfFields = append(msgData.NonOneOfFields, fieldData)
 	}
+	if fieldData.IsOptional {
+		msgData.OptionalFields = append(msgData.OptionalFields, fieldData)
+	}
 
 	// if it's an external dependencies. store in the file data so that they can be collected when every file's finished
 	if isExternal {
@@ -81,7 +84,8 @@ func (r *Registry) analyseField(fileData *data.File, msgData *data.Message, pack
 	}
 
 	// if it's a one of field. register the field data in the group of the same one of index.
-	if fieldData.IsOneOfField { // one of field
+	// internally, optional fields are modeled as OneOf, however, we don't want to include them here.
+	if fieldData.IsOneOfField && !fieldData.IsOptional {
 		index := f.GetOneofIndex()
 		fieldData.OneOfIndex = index
 		_, ok := msgData.OneOfFieldsGroups[index]


### PR DESCRIPTION
Hello @seanami,

The tests passed without any changes, which is reassuring. Here's what the
generated code looks like:

With `emit_unpopulated=true`

```ts
export type OptionalFieldsResponse = {
  emptyStr: string
  emptyNumber: number
  emptyMsg: OptionalFieldsSubMsg | null
  emptyOptStr?: string
  emptyOptNumber?: number
  emptyOptMsg?: OptionalFieldsSubMsg | null
  zeroStr: string
  zeroNumber: number
  zeroMsg: OptionalFieldsSubMsg | null
  zeroOptStr?: string
  zeroOptNumber?: number
  zeroOptMsg?: OptionalFieldsSubMsg
  definedStr: string
  definedNumber: number
  definedMsg: OptionalFieldsSubMsg | null
  definedOptStr?: string
  definedOptNumber?: number
  definedOptMsg?: OptionalFieldsSubMsg | null
}

export type OptionalFieldsSubMsg = {
  str: string
  optStr?: string
}
```

And with `emit_unpopulated=false`:

```ts
export type OptionalFieldsResponse = {
  emptyStr?: string
  emptyNumber?: number
  emptyMsg?: OptionalFieldsSubMsg
  emptyOptStr?: string
  emptyOptNumber?: number
  emptyOptMsg?: OptionalFieldsSubMsg
  zeroStr?: string
  zeroNumber?: number
  zeroMsg?: OptionalFieldsSubMsg
  zeroOptStr?: string
  zeroOptNumber?: number
  zeroOptMsg?: OptionalFieldsSubMsg
  definedStr?: string
  definedNumber?: number
  definedMsg?: OptionalFieldsSubMsg
  definedOptStr?: string
  definedOptNumber?: number
  definedOptMsg?: OptionalFieldsSubMsg
}

export type OptionalFieldsSubMsg = {
  str?: string
  optStr?: string
}
```

Please review the following commits I made in branch dan/optional-again:

7444de92d6f92a210093155370e2b51b3c8422c0 (2024-04-26 16:07:33 -0700)
Use field_name?: field_type for optional fields, instead of OneOf extension, see #5

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics