### PR TITLE
Fix type warning in b64 encode function

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -126,7 +126,7 @@ for (let i = 0; i < 64;) {
 }
 
 export function b64Encode(buffer: Uint8Array, start: number, end: number): string {
-	let parts: string[] = null;
+  let parts: string[] | null = null;
   const chunk = [];
   let i = 0; // output index
   let j = 0; // goto index


### PR DESCRIPTION
Hello @,

Please review the following commits I made in branch dan/types:

4296f21a8a6e1711886450956078fb0d76e0883e (2024-05-06 17:29:18 -0700)
Fix type warning in b64 encode function

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics