### PR TITLE
Cleanup a lot more lint warnings, and format TS more idiomatically

### DIFF
--- a/generator/fetch.pb.ts
+++ b/generator/fetch.pb.ts
@@ -1,0 +1,340 @@
+/*
+ * This file is a created by the TypeScript generator for the GRPC Gateway.
+ * DO NOT MODIFY
+ */
+
+/**
+ * base64 encoder and decoder
+ * Copied and adapted from https://github.com/protobufjs/protobuf.js/blob/master/lib/base64/index.js
+ */
+
+// Base64 encoding table
+const b64 = new Array<number>(64);
+
+// Base64 decoding table
+const s64 = new Array<number>(123);
+
+// 65..90, 97..122, 48..57, 43, 47
+for (let i = 0; i < 64; ) {
+  s64[
+    (b64[i] =
+      i < 26 ? i + 65 : i < 52 ? i + 71 : i < 62 ? i - 4 : (i - 59) | 43)
+  ] = i++;
+}
+
+export function b64Encode(
+  buffer: Uint8Array,
+  start: number,
+  end: number
+): string {
+  let parts: string[] | null = null;
+  const chunk: number[] = [];
+  let i = 0; // output index
+  let j = 0; // goto index
+  let t = 0; // temporary
+  while (start < end) {
+    const b = buffer[start++];
+    switch (j) {
+      case 0:
+        chunk[i++] = b64[b >> 2];
+        t = (b & 3) << 4;
+        j = 1;
+        break;
+      case 1:
+        chunk[i++] = b64[t | (b >> 4)];
+        t = (b & 15) << 2;
+        j = 2;
+        break;
+      case 2:
+        chunk[i++] = b64[t | (b >> 6)];
+        chunk[i++] = b64[b & 63];
+        j = 0;
+        break;
+    }
+    if (i > 8191) {
+      (parts ?? (parts = [])).push(String.fromCharCode(...chunk));
+      i = 0;
+    }
+  }
+  if (j) {
+    chunk[i++] = b64[t];
+    chunk[i++] = 61;
+    if (j === 1) chunk[i++] = 61;
+  }
+  if (parts) {
+    if (i) parts.push(String.fromCharCode(...chunk.slice(0, i)));
+    return parts.join("");
+  }
+  return String.fromCharCode(...chunk.slice(0, i));
+}
+
+const invalidEncoding = "invalid encoding";
+
+export function b64Decode(s: string): Uint8Array {
+  const buffer: number[] = [];
+  let offset = 0;
+  let j = 0; // goto index
+  let t = 0; // temporary
+  for (let i = 0; i < s.length; ) {
+    let c = s.charCodeAt(i++);
+    if (c === 61 && j > 1) break;
+    if ((c = s64[c]) === undefined) throw Error(invalidEncoding);
+    switch (j) {
+      case 0:
+        t = c;
+        j = 1;
+        break;
+      case 1:
+        buffer[offset++] = (t << 2) | ((c & 48) >> 4);
+        t = c;
+        j = 2;
+        break;
+      case 2:
+        buffer[offset++] = ((t & 15) << 4) | ((c & 60) >> 2);
+        t = c;
+        j = 3;
+        break;
+      case 3:
+        buffer[offset++] = ((t & 3) << 6) | c;
+        j = 0;
+        break;
+    }
+  }
+  if (j === 1) throw Error(invalidEncoding);
+  return new Uint8Array(buffer);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function b64Test(s: string): boolean {
+  return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+    s
+  );
+}
+
+export interface InitReq extends RequestInit {
+  pathPrefix?: string;
+}
+
+export function replacer(_key: string, value: unknown): unknown {
+  if (value && value instanceof Uint8Array) {
+    return b64Encode(value, 0, value.length);
+  }
+  return value;
+}
+
+export function fetchRequest<R>(path: string, init?: InitReq): Promise<R> {
+  const { pathPrefix, ...req } = init ?? {};
+
+  const url = pathPrefix ? `${pathPrefix}${path}` : path;
+
+  return fetch(url, req).then((r) =>
+    r
+      .json()
+      .catch((_err) => {
+        throw r;
+      })
+      .then((body: R) => {
+        if (!r.ok) throw body;
+        return body;
+      })
+  );
+}
+
+// NotifyStreamEntityArrival is a callback that will be called on streaming entity arrival
+export type NotifyStreamEntityArrival<T> = (resp: T) => void;
+
+/**
+ * fetchStreamingRequest is able to handle grpc-gateway server side streaming call
+ * it takes NotifyStreamEntityArrival that lets users respond to entity arrival during the call
+ * all entities will be returned as an array after the call finishes.
+ **/
+export async function fetchStreamingRequest<R>(
+  path: string,
+  callback?: NotifyStreamEntityArrival<R>,
+  init?: InitReq
+) {
+  const { pathPrefix, ...req } = init ?? {};
+  const url = pathPrefix ? `${pathPrefix}${path}` : path;
+  const result = await fetch(url, req);
+  // needs to use the .ok to check the status of HTTP status code
+  // http other than 200 will not throw an error, instead the .ok will become false.
+  // see https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#
+  if (!result.ok) {
+    const resp = (await result.json()) as { error?: { message?: string } };
+    const errMsg = resp?.error?.message ?? "unknown error";
+    throw new Error(errMsg);
+  }
+
+  if (!result.body) {
+    throw new Error("response does not have a body");
+  }
+
+  await result.body
+    .pipeThrough(new TextDecoderStream())
+    .pipeThrough<R>(getNewLineDelimitedJSONDecodingStream<R>())
+    .pipeTo(
+      getNotifyEntityArrivalSink((e: R) => {
+        if (callback) callback(e);
+      })
+    );
+
+  // wait for the streaming to finish and return the success respond
+  return;
+}
+
+/**
+ * JSONStringStreamController represents the transform controller that's able to
+ * transform the incoming new line delimited json content stream into entities
+ * and able to push the entity to the down stream.
+ */
+interface JSONStringStreamController<T>
+  extends TransformStreamDefaultController {
+  buf?: string;
+  pos?: number;
+  enqueue: (s: T) => void;
+}
+
+/**
+ * Returns a TransformStream that's able to handle new line delimited json
+ * stream content into parsed entities
+ */
+function getNewLineDelimitedJSONDecodingStream<T>(): TransformStream<
+  string,
+  T
+> {
+  return new TransformStream({
+    start(controller: JSONStringStreamController<T>) {
+      controller.buf = "";
+      controller.pos = 0;
+    },
+
+    transform(chunk: string, controller: JSONStringStreamController<T>) {
+      if (controller.buf === undefined) {
+        controller.buf = "";
+      }
+      if (controller.pos === undefined) {
+        controller.pos = 0;
+      }
+      controller.buf += chunk;
+      while (controller.pos < controller.buf.length) {
+        if (controller.buf[controller.pos] === "\n") {
+          const line = controller.buf.substring(0, controller.pos);
+          const response = JSON.parse(line) as { result: T };
+          controller.enqueue(response.result);
+          controller.buf = controller.buf.substring(controller.pos + 1);
+          controller.pos = 0;
+        } else {
+          ++controller.pos;
+        }
+      }
+    },
+  });
+}
+
+/**
+ * Takes the NotifyStreamEntityArrival callback and return a sink that will call
+ * the callback on entity arrival.
+ */
+function getNotifyEntityArrivalSink<T>(
+  notifyCallback: NotifyStreamEntityArrival<T>
+) {
+  return new WritableStream<T>({
+    write(entity: T) {
+      notifyCallback(entity);
+    },
+  });
+}
+
+type Primitive = string | boolean | number;
+type RequestPayload = Record<string, unknown>;
+type FlattenedRequestPayload = Record<string, Primitive | Primitive[]>;
+
+/**
+ * Checks if given value is a plain object
+ * Logic copied and adapted from below source:
+ * https://github.com/char0n/ramda-adjunct/blob/master/src/isPlainObj.js
+ */
+function isPlainObject(value: unknown): boolean {
+  const isObject =
+    Object.prototype.toString.call(value).slice(8, -1) === "Object";
+  const isObjLike = value !== null && isObject;
+
+  if (!isObjLike || !isObject) {
+    return false;
+  }
+
+  const proto: unknown = Object.getPrototypeOf(value);
+
+  const hasObjectConstructor = !!(
+    proto &&
+    typeof proto === "object" &&
+    proto.constructor === Object.prototype.constructor
+  );
+
+  return hasObjectConstructor;
+}
+
+/**
+ * Checks if given value is of a primitive type
+ */
+function isPrimitive(value: unknown): boolean {
+  return ["string", "number", "boolean"].some((t) => typeof value === t);
+}
+
+/**
+ * Flattens a deeply nested request payload and returns an object
+ * with only primitive values and non-empty array of primitive values
+ * as per https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
+ */
+function flattenRequestPayload<T extends RequestPayload>(
+  requestPayload: T,
+  path = ""
+): FlattenedRequestPayload {
+  return Object.keys(requestPayload).reduce((acc: T, key: string): T => {
+    const value = requestPayload[key];
+    const newPath = path ? [path, key].join(".") : key;
+
+    const isNonEmptyPrimitiveArray =
+      Array.isArray(value) &&
+      value.every((v) => isPrimitive(v)) &&
+      value.length > 0;
+
+    let objectToMerge = {};
+
+    if (isPlainObject(value)) {
+      objectToMerge = flattenRequestPayload(value as RequestPayload, newPath);
+    } else if (isPrimitive(value) || isNonEmptyPrimitiveArray) {
+      objectToMerge = { [newPath]: value };
+    }
+
+    return { ...acc, ...objectToMerge };
+  }, {} as T) as FlattenedRequestPayload;
+}
+
+/**
+ * Renders a deeply nested request payload into a string of URL search
+ * parameters by first flattening the request payload and then removing keys
+ * which are already present in the URL path.
+ */
+export function renderURLSearchParams<T extends RequestPayload>(
+  requestPayload: T,
+  urlPathParams: string[] = []
+): string {
+  const flattenedRequestPayload = flattenRequestPayload(requestPayload);
+
+  const urlSearchParams = Object.keys(flattenedRequestPayload).reduce(
+    (acc: string[][], key: string): string[][] => {
+      // key should not be present in the url path as a parameter
+      const value = flattenedRequestPayload[key];
+      if (urlPathParams.find((f) => f === key)) {
+        return acc;
+      }
+      return Array.isArray(value)
+        ? [...acc, ...value.map((m) => [key, m.toString()])]
+        : (acc = [...acc, [key, value.toString()]]);
+    },
+    [] as string[][]
+  );
+
+  return new URLSearchParams(urlSearchParams).toString();
+}

--- a/generator/fetchtmpl.go
+++ b/generator/fetchtmpl.go
@@ -1,0 +1,14 @@
+package generator
+
+import _ "embed"
+
+//go:embed fetch.pb.ts
+var fetchTmplScript string
+
+var fetchTmplHeader = `{{- if not .EnableStylingCheck}}
+/* eslint-disable */
+// @ts-nocheck
+{{- end}}
+`
+
+var fetchTmpl = fetchTmplHeader + fetchTmplScript

--- a/generator/template.go
+++ b/generator/template.go
@@ -18,74 +18,98 @@ import (
 )
 
 const tmpl = `
-{{define "dependencies"}}
-{{range .}}import * as {{.ModuleIdentifier}} from "{{.SourceFile}}"
-{{end}}{{end}}
+{{- define "dependencies" -}}
+{{- range . -}}
+  import * as {{.ModuleIdentifier}} from "{{.SourceFile}}";
+{{end}}
+{{end -}}
 
-{{define "enums"}}
-{{range .}}export enum {{.Name}} {
-{{- range .Values}}
+{{- define "enums" -}}
+{{- range .}}
+export enum {{.Name}} {
+  {{- range .Values}}
   {{.}} = "{{.}}",
-{{- end}}
-}
+  {{- end}}
+};
 
-{{end}}{{end}}
+{{end -}}
+{{- end -}}
 
-{{define "messages"}}{{range .}}
-{{- if .HasOneOfFields}}
+{{- define "messages" -}}
+{{- range . -}}
+{{- if .HasOneOfFields -}}
 type Base{{.Name}} = {
 {{- range .NonOneOfFields}}
-  {{tsTypeKey .}}: {{tsTypeDef .}}
+  {{tsTypeKey .}}: {{tsTypeDef .}};
 {{- end}}
-{{- range .OptionalFields}}
-  {{tsTypeKey .}}: {{tsTypeDef .}}
+{{- range .OptionalFields -}}
+  {{tsTypeKey .}}: {{tsTypeDef .}};
 {{- end}}
-}
+};
 
 export type {{.Name}} = Base{{.Name}}
-{{range $groupId, $fields := .OneOfFieldsGroups}}  & OneOf<{ {{range $index, $field := $fields}}{{fieldName $field.Name}}: {{tsType $field}}{{if (lt (add $index 1) (len $fields))}}; {{end}}{{end}} }>
-{{end}}
-{{- else -}}
-export type {{.Name}} = {
-{{- range .Fields}}
-  {{tsTypeKey .}}: {{tsTypeDef .}}
-{{- end}}
-}
-{{end}}
-{{end}}{{end}}
+{{- range $groupId, $fields := .OneOfFieldsGroups}} &
+  OneOf<{ {{range $index, $field := $fields}}{{fieldName $field.Name}}: {{tsType $field}}{{if (lt (add $index 1) (len $fields))}}; {{end}}{{end}} }>;
+{{- end -}}
 
-{{define "services"}}{{range .}}export class {{.Name}} {
+{{/* Standard, non oneof messages */}}
+
+{{- else -}}
+{{- if eq (len .Fields) 0 -}}
+  export type {{.Name}} = Record<string, never>;
+{{- else -}}
+  export type {{.Name}} = {
+{{- range .Fields}}
+  {{tsTypeKey .}}: {{tsTypeDef .}};
+{{- end}}
+};
+    {{- end -}}
+  {{- end}}
+
+{{end -}}
+{{- end}}
+
+{{define "services" -}}
+{{- range . -}}
+export class {{.Name}} {
 {{- range .Methods}}
 {{- if .ServerStreaming }}
-  static {{.Name}}(req: {{tsType .Input}}, entityNotifier?: fm.NotifyStreamEntityArrival<{{tsType .Output}}>, initReq?: fm.InitReq): Promise<void> {
-    return fm.fetchStreamingRequest<{{tsType .Output}}>(` + "`{{renderURL .}}`" + `, entityNotifier, {...initReq, {{buildInitReq .}}})
+  static {{.Name}}(this:void, req: {{tsType .Input}}, entityNotifier?: fm.NotifyStreamEntityArrival<{{tsType .Output}}>, initReq?: fm.InitReq): Promise<void> {
+    return fm.fetchStreamingRequest<{{tsType .Output}}>(` + "`{{renderURL .}}`" + `, entityNotifier, {...initReq, {{buildInitReq .}}});
   }
 {{- else }}
-  static {{.Name}}(req: {{tsType .Input}}, initReq?: fm.InitReq): Promise<{{tsType .Output}}> {
-    return fm.fetchRequest<{{tsType .Output}}>(` + "`{{renderURL .}}`" + `, {...initReq, {{buildInitReq .}}})
+  static {{.Name}}(this:void, req: {{tsType .Input}}, initReq?: fm.InitReq): Promise<{{tsType .Output}}> {
+    return fm.fetchRequest<{{tsType .Output}}>(` + "`{{renderURL .}}`" + `, {...initReq, {{buildInitReq .}}});
   }
 {{- end}}
 {{- end}}
 }
-{{end}}{{end}}
 
-{{- if not .EnableStylingCheck}}
+{{end}}
+{{end}}
+
+{{- if not .EnableStylingCheck -}}
 /* eslint-disable */
 // @ts-nocheck
+{{- else -}}
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
 {{- end}}
-/*
-* This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
-*/
+
+/**
+ * This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
+ */
+
 {{if .Dependencies}}{{- include "dependencies" .StableDependencies -}}{{end}}
-{{- if .NeedsOneOfSupport}}
+{{- if .NeedsOneOfSupport -}}
 type Absent<T, K extends keyof T> = { [k in Exclude<keyof T, K>]?: undefined };
+
 type OneOf<T> =
   | { [k in keyof T]?: undefined }
-  | (
-    keyof T extends infer K ?
-      (K extends string & keyof T ? { [k in K]: T[K] } & Absent<T, K>
-        : never)
-    : never);
+  | (keyof T extends infer K
+      ? K extends string & keyof T
+        ? { [k in K]: T[K] } & Absent<T, K>
+        : never
+      : never);
 {{end}}
 {{- if .NeedsStructPBSupport}}
 type StructPBValue =
@@ -99,333 +123,6 @@ type StructPBValue =
 {{- if .Enums}}{{include "enums" .Enums}}{{end}}
 {{- if .Messages}}{{include "messages" .Messages}}{{end}}
 {{- if .Services}}{{include "services" .Services}}{{end}}
-`
-
-const fetchTmpl = `
-{{- if not .EnableStylingCheck}}
-/* eslint-disable */
-// @ts-nocheck
-{{- end}}
-/*
-* This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
-*/
-
-/**
- * base64 encoder and decoder
- * Copied and adapted from https://github.com/protobufjs/protobuf.js/blob/master/lib/base64/index.js
- */
-// Base64 encoding table
-const b64 = new Array(64);
-
-// Base64 decoding table
-const s64 = new Array(123);
-
-// 65..90, 97..122, 48..57, 43, 47
-for (let i = 0; i < 64;) {
-  s64[b64[i] = i < 26 ? i + 65 : i < 52 ? i + 71 : i < 62 ? i - 4 : i - 59 | 43] = i++;
-}
-
-export function b64Encode(buffer: Uint8Array, start: number, end: number): string {
-  let parts: string[] | null = null;
-  const chunk = [];
-  let i = 0; // output index
-  let j = 0; // goto index
-  let t = 0; // temporary
-  while (start < end) {
-    const b = buffer[start++];
-    switch (j) {
-      case 0:
-        chunk[i++] = b64[b >> 2];
-        t = (b & 3) << 4;
-        j = 1;
-        break;
-      case 1:
-        chunk[i++] = b64[t | (b >> 4)];
-        t = (b & 15) << 2;
-        j = 2;
-        break;
-      case 2:
-        chunk[i++] = b64[t | (b >> 6)];
-        chunk[i++] = b64[b & 63];
-        j = 0;
-        break;
-    }
-    if (i > 8191) {
-      (parts || (parts = [])).push(String.fromCharCode.apply(String, chunk));
-      i = 0;
-    }
-  }
-  if (j) {
-    chunk[i++] = b64[t];
-    chunk[i++] = 61;
-    if (j === 1) chunk[i++] = 61;
-  }
-  if (parts) {
-    if (i) parts.push(String.fromCharCode.apply(String, chunk.slice(0, i)));
-    return parts.join("");
-  }
-  return String.fromCharCode.apply(String, chunk.slice(0, i));
-}
-
-const invalidEncoding = "invalid encoding";
-
-export function b64Decode(s: string): Uint8Array {
-	const buffer = [];
-	let offset = 0;
-  let j = 0; // goto index
-  let t = 0; // temporary
-  for (let i = 0; i < s.length;) {
-    let c = s.charCodeAt(i++);
-    if (c === 61 && j > 1)
-        break;
-    if ((c = s64[c]) === undefined)
-        throw Error(invalidEncoding);
-    switch (j) {
-      case 0:
-        t = c;
-        j = 1;
-        break;
-      case 1:
-        buffer[offset++] = (t << 2) | ((c & 48) >> 4);
-        t = c;
-        j = 2;
-        break;
-      case 2:
-        buffer[offset++] = ((t & 15) << 4) | ((c & 60) >> 2);
-        t = c;
-        j = 3;
-        break;
-      case 3:
-        buffer[offset++] = ((t & 3) << 6) | c;
-        j = 0;
-        break;
-    }
-  }
-  if (j === 1) throw Error(invalidEncoding);
-  return new Uint8Array(buffer);
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function b64Test(s: string): boolean {
-	return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(s);
-}
-
-export interface InitReq extends RequestInit {
-  pathPrefix?: string
-}
-
-export function replacer(key: any, value: any): any {
-  if(value && value.constructor === Uint8Array) {
-    return b64Encode(value, 0, value.length);
-  }
-
-  return value;
-}
-
-export function fetchRequest<R>(path: string, init?: any): Promise<R> {
-  const {pathPrefix, ...req} = init || {}
-
-  const url = pathPrefix ? ` + "`${pathPrefix}${path}`" + ` : path
-
-  return fetch(url, req).then((r) =>
-    r
-      .json()
-      .catch((err) => { throw r; })
-      .then((body: R) => {
-        if (!r.ok) { throw body; }
-        return body;
-      }),
-   ) as Promise<R>;
-}
-
-// NotifyStreamEntityArrival is a callback that will be called on streaming entity arrival
-export type NotifyStreamEntityArrival<T> = (resp: T) => void
-
-/**
- * fetchStreamingRequest is able to handle grpc-gateway server side streaming call
- * it takes NotifyStreamEntityArrival that lets users respond to entity arrival during the call
- * all entities will be returned as an array after the call finishes.
- **/
-export async function fetchStreamingRequest<R>(path: string, callback?: NotifyStreamEntityArrival<R>, init?: any) {
-  const {pathPrefix, ...req} = init || {}
-  const url = pathPrefix ?` + "`${pathPrefix}${path}`" + ` : path
-  const result = await fetch(url, req)
-  // needs to use the .ok to check the status of HTTP status code
-  // http other than 200 will not throw an error, instead the .ok will become false.
-  // see https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#
-  if (!result.ok) {
-    const resp = await result.json()
-    const errMsg = resp.error && resp.error.message ? resp.error.message : ""
-    throw new Error(errMsg)
-  }
-
-  if (!result.body) {
-    throw new Error("response doesnt have a body")
-  }
-
-  await result.body
-    .pipeThrough(new TextDecoderStream())
-    .pipeThrough<R>(getNewLineDelimitedJSONDecodingStream<R>())
-    .pipeTo(getNotifyEntityArrivalSink((e: R) => {
-      if (callback) {
-        callback(e)
-      }
-    }))
-
-  // wait for the streaming to finish and return the success respond
-  return
-}
-
-/**
- * JSONStringStreamController represents the transform controller that's able to transform the incoming
- * new line delimited json content stream into entities and able to push the entity to the down stream
- */
-interface JSONStringStreamController<T> extends TransformStreamDefaultController {
-  buf?: string
-  pos?: number
-  enqueue: (s: T) => void
-}
-
-/**
- * getNewLineDelimitedJSONDecodingStream returns a TransformStream that's able to handle new line delimited json stream content into parsed entities
- */
-function getNewLineDelimitedJSONDecodingStream<T>(): TransformStream<string, T> {
-  return new TransformStream({
-    start(controller: JSONStringStreamController<T>) {
-      controller.buf = ''
-      controller.pos = 0
-    },
-
-    transform(chunk: string, controller: JSONStringStreamController<T>) {
-      if (controller.buf === undefined) {
-        controller.buf = ''
-      }
-      if (controller.pos === undefined) {
-        controller.pos = 0
-      }
-      controller.buf += chunk
-      while (controller.pos < controller.buf.length) {
-        if (controller.buf[controller.pos] === '\n') {
-          const line = controller.buf.substring(0, controller.pos)
-          const response = JSON.parse(line)
-          controller.enqueue(response.result)
-          controller.buf = controller.buf.substring(controller.pos + 1)
-          controller.pos = 0
-        } else {
-          ++controller.pos
-        }
-      }
-    }
-  })
-
-}
-
-/**
- * getNotifyEntityArrivalSink takes the NotifyStreamEntityArrival callback and return
- * a sink that will call the callback on entity arrival
- */
-function getNotifyEntityArrivalSink<T>(notifyCallback: NotifyStreamEntityArrival<T>) {
-  return new WritableStream<T>({
-    write(entity: T) {
-      notifyCallback(entity)
-    }
-  })
-}
-
-type Primitive = string | boolean | number;
-type RequestPayload = Record<string, unknown>;
-type FlattenedRequestPayload = Record<string, Primitive | Array<Primitive>>;
-
-/**
- * Checks if given value is a plain object
- * Logic copied and adapted from below source:
- * https://github.com/char0n/ramda-adjunct/blob/master/src/isPlainObj.js
- */
-function isPlainObject(value: unknown): boolean {
-  const isObject =
-    Object.prototype.toString.call(value).slice(8, -1) === "Object";
-  const isObjLike = value !== null && isObject;
-
-  if (!isObjLike || !isObject) {
-    return false;
-  }
-
-  const proto = Object.getPrototypeOf(value);
-
-  const hasObjectConstructor =
-    typeof proto === "object" &&
-    proto.constructor === Object.prototype.constructor;
-
-  return hasObjectConstructor;
-}
-
-/**
- * Checks if given value is of a primitive type
- */
-function isPrimitive(value: unknown): boolean {
-  return ["string", "number", "boolean"].some(t => typeof value === t);
-}
-
-/**
- * Flattens a deeply nested request payload and returns an object
- * with only primitive values and non-empty array of primitive values
- * as per https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
- */
-function flattenRequestPayload<T extends RequestPayload>(
-  requestPayload: T,
-  path: string = ""
-): FlattenedRequestPayload {
-  return Object.keys(requestPayload).reduce(
-    (acc: T, key: string): T => {
-      const value = requestPayload[key];
-      const newPath = path ? [path, key].join(".") : key;
-
-      const isNonEmptyPrimitiveArray =
-        Array.isArray(value) &&
-        value.every(v => isPrimitive(v)) &&
-        value.length > 0;
-
-      let objectToMerge = {};
-
-      if (isPlainObject(value)) {
-        objectToMerge = flattenRequestPayload(value as RequestPayload, newPath);
-      } else if (isPrimitive(value) || isNonEmptyPrimitiveArray) {
-        objectToMerge = { [newPath]: value };
-      }
-
-      return { ...acc, ...objectToMerge };
-    },
-    {} as T
-  ) as FlattenedRequestPayload;
-}
-
-/**
- * Renders a deeply nested request payload into a string of URL search
- * parameters by first flattening the request payload and then removing keys
- * which are already present in the URL path.
- */
-export function renderURLSearchParams<T extends RequestPayload>(
-  requestPayload: T,
-  urlPathParams: string[] = []
-): string {
-  const flattenedRequestPayload = flattenRequestPayload(requestPayload);
-
-  const urlSearchParams = Object.keys(flattenedRequestPayload).reduce(
-    (acc: string[][], key: string): string[][] => {
-      // key should not be present in the url path as a parameter
-      const value = flattenedRequestPayload[key];
-      if (urlPathParams.find(f => f === key)) {
-        return acc;
-      }
-      return Array.isArray(value)
-        ? [...acc, ...value.map(m => [key, m.toString()])]
-        : (acc = [...acc, [key, value.toString()]]);
-    },
-    [] as string[][]
-  );
-
-  return new URLSearchParams(urlSearchParams).toString();
-}
 `
 
 // GetTemplate gets the templates to for the typescript file
@@ -508,7 +205,6 @@ func buildInitReq(method data.Method) string {
 	}
 
 	return strings.Join(fields, ", ")
-
 }
 
 // GetFetchModuleTemplate returns the go template for fetch module
@@ -564,7 +260,7 @@ func tsType(r *registry.Registry, fieldType data.Type) string {
 		keyType := tsType(r, typeInfo.KeyType)
 		valueType := tsType(r, typeInfo.ValueType)
 
-		return fmt.Sprintf("{[key: %s]: %s}", keyType, valueType)
+		return fmt.Sprintf("Record<%s, %s>", keyType, valueType)
 	}
 	typeStr := ""
 	if mapWellKnownType(info.Type) != "" {


### PR DESCRIPTION
Hello @seanami,

There are two potentially important changes here:

- Empty request/response objects are now explicitly defined as `Record<string, never>`,
  this is to fix the error because an `{}` interface matches any non-null type. 
- Map fields now use record types, per recommendations.

A change that I didn't make was to switch from `type` to `interface` which was
also recommended by eslint. I'm not quite sure what the implications of that are
yet.

--

Please review the following commits I made in branch dan/types:

6fff30369c45cd1a268ce0a84e5257c46046374f (2024-05-07 14:58:58 -0700)
Cleanup a lot more lint warnings, and format TS more idiomatically

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics