### PR TITLE
Fix unnecessary semi-colon in enums

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -29,7 +29,7 @@ export enum {{.Name}} {
   {{- range .Values}}
   {{.}} = "{{.}}",
   {{- end}}
-};
+}
 
 {{end -}}
 {{- end -}}


### PR DESCRIPTION
Please review the following commits I made in branch dan/deprecated:

18634ce30784c12c4faa891c1c061df4630766df (2024-05-11 17:56:42 -0700)
Fix unnecessary semi-colon in enums

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics