### PR TITLE
Use dot-notation when building parameterized paths

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -113,6 +113,7 @@ export class {{.Name}} {
 // @ts-nocheck
 {{- else -}}
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
+/* eslint-disable @typescript-eslint/dot-notation */
 {{- end}}
 
 /**
@@ -187,7 +188,7 @@ func renderURL(r *registry.Registry) func(method data.Method) string {
 			for _, m := range matches {
 				expToReplace := m[0]
 				fieldName := fieldNameFn(m[1])
-				part := fmt.Sprintf(`${req["%s"]}`, fieldName)
+				part := fmt.Sprintf(`${req.%s}`, fieldName)
 				methodURL = strings.ReplaceAll(methodURL, expToReplace, part)
 				fieldsInPath = append(fieldsInPath, fmt.Sprintf(`"%s"`, fieldName))
 			}


### PR DESCRIPTION
Hello, this fixes another strict TS warning.

Please review the following commits I made in branch dan/dotnotation:

ce80cf489a725c91be86e0246ba7a2107ca7dd41 (2024-05-16 09:15:21 -0700)
Use dot-notation when building parameterized paths

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics