### PR TITLE
Support query params on DELETE requests, closes #29

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -96,7 +96,7 @@ func renderURL(r *registry.Registry) func(method data.Method) string {
 		}
 		urlPathParams := fmt.Sprintf("[%s]", strings.Join(fieldsInPath, ", "))
 
-		if !method.ClientStreaming && method.HTTPMethod == "GET" {
+		if !method.ClientStreaming && (method.HTTPMethod == "GET" || method.HTTPMethod == "DELETE") {
 			// parse the url to check for query string
 			parsedURL, err := url.Parse(methodURL)
 			if err != nil {

--- a/generator/template_test.go
+++ b/generator/template_test.go
@@ -24,6 +24,9 @@ func TestFieldName(t *testing.T) {
 		{useProtoNames: false, input: "foo3_bar", want: "foo3Bar"},
 		{useProtoNames: false, input: "foo_3bar", want: "foo3bar"},
 		{useProtoNames: false, input: "foo_3_bar", want: "foo3Bar"},
+
+		{useProtoNames: true, input: "k8s_field", want: "k8s_field"},
+		{useProtoNames: true, input: "foo_bar", want: "foo_bar"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/test/integration/defaultConfig/defaultConfig_test.ts
+++ b/test/integration/defaultConfig/defaultConfig_test.ts
@@ -100,6 +100,14 @@ describe("test default configuration", () => {
     expect(result).to.be.empty;
   });
 
+  it("http delete with query params", async () => {
+    const result = await CounterService.HTTPDeleteWithParams(
+      { id: 10, reason: "test" },
+      { pathPrefix: "http://localhost:8081" }
+    );
+    expect(result.reason).to.be.equal("test");
+  });
+
   it("http get request with url search parameters", async () => {
     const result = await CounterService.HTTPGetWithURLSearchParams(
       { a: 10, b: { b: 0 }, c: [23, 25], d: { d: 12 } },

--- a/test/integration/noStaticClasses/noStaticClasses_test.ts
+++ b/test/integration/noStaticClasses/noStaticClasses_test.ts
@@ -10,20 +10,14 @@ import { b64Decode } from "./fetch.pb";
 
 describe("test static functions", () => {
   it("unary request", async () => {
-    const result = await increment(
-      { counter: 199 },
-      { pathPrefix: "http://localhost:8081" }
-    );
+    const result = await increment({ counter: 199 });
 
     expect(result.result).to.equal(200);
   });
 
   it("failing unary request", async () => {
     try {
-      await failingIncrement(
-        { counter: 199 },
-        { pathPrefix: "http://localhost:8081" }
-      );
+      await failingIncrement({ counter: 199 });
       expect.fail("expected call to throw");
     } catch (e) {
       expect(e).to.have.property("message", "this increment does not work");
@@ -33,10 +27,8 @@ describe("test static functions", () => {
 
   it("streaming request", async () => {
     const response = [] as number[];
-    await streamingIncrements(
-      { counter: 1 },
-      (resp) => response.push(resp.result),
-      { pathPrefix: "http://localhost:8081" }
+    await streamingIncrements({ counter: 1 }, (resp) =>
+      response.push(resp.result)
     );
     expect(response).to.deep.equal([2, 3, 4, 5, 6]);
   });
@@ -67,65 +59,67 @@ describe("test with client class", () => {
 
   it("http get check request", async () => {
     const req = { numToIncrease: 10 } as HttpGetRequest;
-    const result = await client.httpGet(req, {
-      pathPrefix: "http://localhost:8081",
-    });
+    const result = await client.httpGet(req);
     expect(result.result).to.equal(11);
   });
 
   it("http post body check request with nested body path", async () => {
-    const result = await client.httpPostWithNestedBodyPath(
-      { a: 10, req: { b: 15 }, c: 0 },
-      { pathPrefix: "http://localhost:8081" }
-    );
+    const result = await client.httpPostWithNestedBodyPath({
+      a: 10,
+      req: { b: 15 },
+      c: 0,
+    });
     expect(result.postResult).to.equal(25);
   });
 
   it("http post body check request with star in path", async () => {
-    const result = await client.httpPostWithStarBodyPath(
-      { a: 10, req: { b: 15 }, c: 23 },
-      { pathPrefix: "http://localhost:8081" }
-    );
+    const result = await client.httpPostWithStarBodyPath({
+      a: 10,
+      req: { b: 15 },
+      c: 23,
+    });
     expect(result.postResult).to.equal(48);
   });
 
   it("able to communicate with external message reference without package defined", async () => {
-    const result = await client.externalMessage(
-      { content: "hello" },
-      { pathPrefix: "http://localhost:8081" }
-    );
+    const result = await client.externalMessage({ content: "hello" });
     expect(result.result).to.equal("hello!!");
   });
 
   it("http patch request with star in path", async () => {
-    const result = await client.httpPatch(
-      { a: 10, c: 23 },
-      { pathPrefix: "http://localhost:8081" }
-    );
+    const result = await client.httpPatch({ a: 10, c: 23 });
     expect(result.patchResult).to.equal(33);
   });
 
   it("http delete check request", async () => {
-    const result = await client.httpDelete(
-      { a: 10 },
-      { pathPrefix: "http://localhost:8081" }
-    );
+    const result = await client.httpDelete({ a: 10 });
     expect(result).to.be.empty;
   });
 
+  it("http delete with query params", async () => {
+    const result = await client.httpDeleteWithParams({
+      id: 10,
+      reason: "test",
+    });
+    expect(result.reason).to.be.equal("test");
+  });
+
   it("http get request with url search parameters", async () => {
-    const result = await client.httpGetWithURLSearchParams(
-      { a: 10, b: { b: 0 }, c: [23, 25], d: { d: 12 } },
-      { pathPrefix: "http://localhost:8081" }
-    );
+    const result = await client.httpGetWithURLSearchParams({
+      a: 10,
+      b: { b: 0 },
+      c: [23, 25],
+      d: { d: 12 },
+    });
     expect(result.urlSearchParamsResult).to.equal(70);
   });
 
   it("http get request with zero value url search parameters", async () => {
-    const result = await client.httpGetWithZeroValueURLSearchParams(
-      { a: "A", b: "", c: { c: 1, d: [1, 0, 2], e: false } },
-      { pathPrefix: "http://localhost:8081" }
-    );
+    const result = await client.httpGetWithZeroValueURLSearchParams({
+      a: "A",
+      b: "",
+      c: { c: 1, d: [1, 0, 2], e: false },
+    });
     expect(result).to.deep.equal({
       a: "A",
       b: "hello",
@@ -134,10 +128,7 @@ describe("test with client class", () => {
   });
 
   it("http get request with optional fields", async () => {
-    const result = await client.httpGetWithOptionalFields(
-      {},
-      { pathPrefix: "http://localhost:8081" }
-    );
+    const result = await client.httpGetWithOptionalFields({});
 
     expect(result).to.deep.equal({
       // all empty fields will be excluded.

--- a/test/integration/protos/service.proto
+++ b/test/integration/protos/service.proto
@@ -77,6 +77,15 @@ message HttpDeleteRequest {
   int32 a = 1;
 }
 
+message HttpDeleteWithParamsRequest {
+  int32 id = 1;
+  string reason = 2;
+}
+
+message HttpDeleteWithParamsResponse {
+  string reason = 1;
+}
+
 message HTTPGetWithURLSearchParamsRequest {
   int32 a = 1;
   PostRequest b = 2;
@@ -198,6 +207,11 @@ service CounterService {
   rpc HTTPDelete(HttpDeleteRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/delete/{a}"
+    };
+  }
+  rpc HTTPDeleteWithParams(HttpDeleteWithParamsRequest) returns (HttpDeleteWithParamsResponse) {
+    option (google.api.http) = {
+      delete: "/delete/{id}"
     };
   }
   rpc ExternalMessage(ExternalRequest) returns (ExternalResponse);

--- a/test/integration/service.go
+++ b/test/integration/service.go
@@ -82,6 +82,10 @@ func (r *RealCounterService) HTTPDelete(ctx context.Context, req *HttpDeleteRequ
 	return &emptypb.Empty{}, nil
 }
 
+func (r *RealCounterService) HTTPDeleteWithParams(ctx context.Context, req *HttpDeleteWithParamsRequest) (*HttpDeleteWithParamsResponse, error) {
+	return &HttpDeleteWithParamsResponse{Reason: req.Reason}, nil
+}
+
 func (r *RealCounterService) HTTPGetWithURLSearchParams(ctx context.Context, in *HTTPGetWithURLSearchParamsRequest) (*HTTPGetWithURLSearchParamsResponse, error) {
 	totalC := 0
 	for _, c := range in.GetC() {


### PR DESCRIPTION
Please review the following commits I made in branch dan/delete-with-params:

00471595e3ebd4325d6977c8639c205a17ee70cd (2024-05-30 16:54:13 -0700)
Support query params on DELETE requests, closes #29

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics