### PR TITLE
Use Typescript bigint type for protobuf int64 types

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -218,7 +218,9 @@ func mapWellKnownType(protoType string) string {
 
 func mapScalaType(protoType string) string {
 	switch protoType {
-	case "uint64", "sint64", "int64", "fixed64", "sfixed64", "string":
+	case "uint64", "sint64", "int64", "fixed64", "sfixed64":
+		return "bigint"
+	case "string":
 		return "string"
 	case "float", "double", "int32", "sint32", "uint32", "fixed32", "sfixed32":
 		return "number"

--- a/test/oneof_test.go
+++ b/test/oneof_test.go
@@ -41,7 +41,7 @@ import {Environment} from "./environment.pb"
         lines: [{
           identifier: "A.method1",
           file: "a.java",
-          line: "233",
+          line: 233n,
         }],
       }],
     },

--- a/test/testdata/tsconfig.json
+++ b/test/testdata/tsconfig.json
@@ -1,25 +1,19 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "esnext",
+    "module": "ES2020",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react",
-    "baseUrl": "../../../",
+    "baseUrl": "../../../"
   },
-  "include": [
-    "./*"
-  ]
+  "include": ["./*"]
 }


### PR DESCRIPTION
#### Summary
This PR updates the type mapping for Protobuf 64-bit integer types so that they now use TypeScript's native `bigint` type. The TypeScript configuration has also been updated to target ES2020, which in the minimum version that supports `bigint`.