### PR TITLE
Fix JSDoc comment escaping for wildcard URL patterns

### DIFF
--- a/generator/service.ts.tmpl
+++ b/generator/service.ts.tmpl
@@ -122,7 +122,7 @@ export type {{.Name}} = Base{{.Name}}
 export class {{.Name}} {
 {{- range .Methods}}
   /**
-   * {{.TSMethodName}} - {{.HTTPMethod}} {{.URL}}
+   * {{.TSMethodName}} - {{.HTTPMethod}} {{escapeJSDoc .URL}}
    */
 {{- if .ServerStreaming }}
   static {{.TSMethodName}}(this:void, req: {{tsType .Input}}, entityNotifier?: fm.NotifyStreamEntityArrival<{{tsType .Output}}>, initReq?: fm.InitReq): Promise<void> {
@@ -141,7 +141,7 @@ export class {{.Name}} {
 {{define "service_client"}}
 {{- range .Methods}}
 /**
- * {{functionCase .TSMethodName}} - {{.HTTPMethod}} {{.URL}}
+ * {{functionCase .TSMethodName}} - {{.HTTPMethod}} {{escapeJSDoc .URL}}
  */
 {{- if .ServerStreaming }}
 export function {{functionCase .TSMethodName}}(req: {{tsType .Input}}, entityNotifier?: fm.NotifyStreamEntityArrival<{{tsType .Output}}>, initReq?: fm.InitReq): Promise<void> {
@@ -160,7 +160,7 @@ export class {{.Name}}Client {
   }
   {{- range .Methods}}
   /**
-   * {{functionCase .TSMethodName}} - {{.HTTPMethod}} {{.URL}}
+   * {{functionCase .TSMethodName}} - {{.HTTPMethod}} {{escapeJSDoc .URL}}
    */
   {{- if .ServerStreaming }}
   {{functionCase .TSMethodName}}(req: {{tsType .Input}}, entityNotifier?: fm.NotifyStreamEntityArrival<{{tsType .Output}}>, initReq?: fm.InitReq): Promise<void> {

--- a/generator/template.go
+++ b/generator/template.go
@@ -56,6 +56,7 @@ func ServiceTemplate(r *registry.Registry) *template.Template {
 		"buildInitReq": buildInitReq,
 		"fieldName":    fieldName(r),
 		"functionCase": functionCase,
+		"escapeJSDoc":  escapeJSDoc,
 	})
 
 	t = template.Must(t.Parse(serviceTmplScript))
@@ -143,6 +144,12 @@ func include(t *template.Template) func(name string, data interface{}) (string, 
 		}
 		return buf.String(), nil
 	}
+}
+
+// escapeJSDoc escapes */ sequences in JSDoc comments to prevent premature comment closure.
+// URLs with wildcards like /api/v1/{name=customers/*/profiles/*} contain */ which breaks JSDoc.
+func escapeJSDoc(s string) string {
+	return strings.ReplaceAll(s, "*/", `*\/`)
 }
 
 func tsTypeKey(r *registry.Registry) func(field *data.Field) string {

--- a/generator/template_test.go
+++ b/generator/template_test.go
@@ -38,3 +38,53 @@ func TestFieldName(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeJSDoc(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "single wildcard slash",
+			input: "/api/v1/{name=customers/*/secrets}",
+			want:  "/api/v1/{name=customers/*\\/secrets}",
+		},
+		{
+			name:  "multiple wildcard slashes",
+			input: "/api/v1/{name=customers/*/profiles/*/secrets}",
+			want:  "/api/v1/{name=customers/*\\/profiles/*\\/secrets}",
+		},
+		{
+			name:  "triple wildcard slashes",
+			input: "/api/v2/{name=a/*/b/*/c/*/items}",
+			want:  "/api/v2/{name=a/*\\/b/*\\/c/*\\/items}",
+		},
+		{
+			name:  "no wildcard slashes",
+			input: "/api/v1/users",
+			want:  "/api/v1/users",
+		},
+		{
+			name:  "trailing wildcard without slash",
+			input: "/api/v1/{name=users/*}",
+			want:  "/api/v1/{name=users/*}",
+		},
+		{
+			name:  "comment closer in text",
+			input: "GET /api/*/",
+			want:  "GET /api/*\\/",
+		},
+		{
+			name:  "no escaping needed",
+			input: "/api/v1/resource",
+			want:  "/api/v1/resource",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := escapeJSDoc(tt.input)
+			assert.Equal(t, tt.want, got, "escapeJSDoc(%s) = %s, want %s", tt.input, got, tt.want)
+		})
+	}
+}

--- a/test/integration/protos/wildcard_urls.proto
+++ b/test/integration/protos/wildcard_urls.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package test;
+
+import "google/api/annotations.proto";
+
+message GetSecretsRequest {
+  string name = 1;
+}
+
+message GetSecretsResponse {
+  repeated string secrets = 1;
+}
+
+message GetItemsRequest {
+  string path = 1;
+}
+
+message GetItemsResponse {
+  repeated string items = 1;
+}
+
+// WildcardService demonstrates wildcard URL patterns that contain */ sequences
+// which would break JSDoc comments without proper escaping
+service WildcardService {
+  // GetSecrets uses a single wildcard pattern
+  rpc GetSecrets(GetSecretsRequest) returns (GetSecretsResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/{name=customers/*/secrets}"
+    };
+  }
+
+  // GetProfileSecrets uses multiple wildcard patterns
+  rpc GetProfileSecrets(GetSecretsRequest) returns (GetSecretsResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/{name=customers/*/profiles/*/secrets}"
+    };
+  }
+
+  // GetNestedItems uses three wildcard patterns
+  rpc GetNestedItems(GetItemsRequest) returns (GetItemsResponse) {
+    option (google.api.http) = {
+      get: "/api/v2/{path=a/*/b/*/c/*/items}"
+    };
+  }
+}


### PR DESCRIPTION
## Problem

When generating TypeScript service definitions, URLs containing wildcard patterns (e.g., /api/v1/{name=customers/*/profiles/*}) include */ sequences in
JSDoc comments. This prematurely closes the JSDoc block, causing TypeScript compilation errors (TS1434).

Example broken output:

```
/**
 * GetSecrets - GET /api/v1/{name=customers/*/profiles/*/secrets}
 */
```

The first */ in the URL closes the comment, leaving the rest as invalid syntax.

## Solution

Escape */ sequences as *\/ in JSDoc comments when rendering URLs from proto annotations.

Fixed output:

```
/**
 * GetSecrets - GET /api/v1/{name=customers/*\/profiles/*\/secrets}
 */
```

## Changes

- Added escapeJSDoc() template function that escapes `*/` → `*\/`
- Applied escaping to URL fields in all JSDoc comment locations (static methods, functions, client methods)
- Added unit tests for the escape function
- Added integration test proto with wildcard URL patterns

This fix enables proper use of AIP-127 style wildcard resource patterns without breaking TypeScript compilation.