### PR TITLE
Automatically decode bytes fields from base64 in responses

### DIFF
--- a/data/file.go
+++ b/data/file.go
@@ -75,6 +75,17 @@ func (f *File) NeedsStructPBSupport() bool {
 	return false
 }
 
+// NeedsBytesDecoders returns true if any messages contain bytes fields requiring decoding.
+func (f *File) NeedsBytesDecoders() bool {
+	for _, m := range f.Messages {
+		if m.HasBytesFields() {
+			return true
+		}
+	}
+
+	return false
+}
+
 // TrackPackageNonScalarType tracks the supplied non scala type in the same package.
 func (f *File) TrackPackageNonScalarType(t Type) {
 	isNonScalarType := strings.Index(t.GetType().Type, ".") == 0

--- a/data/message.go
+++ b/data/message.go
@@ -49,6 +49,16 @@ func (m *Message) HasStructPBFields() bool {
 	return false
 }
 
+// HasBytesFields returns true when the message has bytes fields that need decoding.
+func (m *Message) HasBytesFields() bool {
+	for _, f := range m.Fields {
+		if f.Type == "bytes" {
+			return true
+		}
+	}
+	return false
+}
+
 // NewMessage initialises and return a Message.
 func NewMessage() *Message {
 	return &Message{

--- a/generator/service.ts.tmpl
+++ b/generator/service.ts.tmpl
@@ -43,15 +43,18 @@ type StructPBValue =
 
 {{- range .Messages}}
   {{- include "message" . -}}
+  {{- if .HasBytesFields -}}
+    {{- include "message_decoder" . -}}
+  {{- end -}}
 {{- end}}
 
 {{- if .UseStaticClasses -}}
   {{- range .Services }}
-    {{- include "static_service" . -}}
+    {{- template "static_service" (dict "Service" . "Messages" $.Messages) -}}
   {{- end}}
 {{- else -}}
   {{- range .Services }}
-    {{- include "service_client" . -}}
+    {{- template "service_client" (dict "Service" . "Messages" $.Messages) -}}
   {{- end}}
 {{- end }}
 
@@ -119,8 +122,8 @@ export type {{.Name}} = Base{{.Name}}
 
 
 {{define "static_service"}}
-export class {{.Name}} {
-{{- range .Methods}}
+export class {{.Service.Name}} {
+{{- range .Service.Methods}}
   /**
    * {{.TSMethodName}} - {{.HTTPMethod}} {{.URL}}
    */
@@ -130,7 +133,13 @@ export class {{.Name}} {
   }
 {{- else }}
   static {{.TSMethodName}}(this:void, req: {{tsType .Input}}, initReq?: fm.InitReq): Promise<{{tsType .Output}}> {
-    return fm.fetchRequest<{{tsType .Output}}>(`{{renderURL .}}`, {...initReq, {{buildInitReq .}}});
+    return fm.fetchRequest<{{tsType .Output}}>(`{{renderURL .}}`, {...initReq, {{buildInitReq .}}})
+    {{- $outputType := tsType .Output -}}
+    {{- range $.Messages -}}
+      {{- if and .HasBytesFields (eq .Name $outputType) -}}
+      .then(decode{{.Name}})
+      {{- end -}}
+    {{- end}};
   }
 {{- end}}
 {{- end}}
@@ -139,7 +148,7 @@ export class {{.Name}} {
 {{end}}
 
 {{define "service_client"}}
-{{- range .Methods}}
+{{- range .Service.Methods}}
 /**
  * {{functionCase .TSMethodName}} - {{.HTTPMethod}} {{.URL}}
  */
@@ -149,16 +158,22 @@ export function {{functionCase .TSMethodName}}(req: {{tsType .Input}}, entityNot
 }
 {{- else }}
 export function {{functionCase .TSMethodName}}(req: {{tsType .Input}}, initReq?: fm.InitReq): Promise<{{tsType .Output}}> {
-  return fm.fetchRequest<{{tsType .Output}}>(`{{renderURL .}}`, {...initReq, {{buildInitReq .}}});
+  return fm.fetchRequest<{{tsType .Output}}>(`{{renderURL .}}`, {...initReq, {{buildInitReq .}}})
+  {{- $outputType := tsType .Output -}}
+  {{- range $.Messages -}}
+    {{- if and .HasBytesFields (eq .Name $outputType) -}}
+    .then(decode{{.Name}})
+    {{- end -}}
+  {{- end}};
 }
 {{- end}}
 {{end}}
-export class {{.Name}}Client {
+export class {{.Service.Name}}Client {
   private initReq?: fm.InitReq;
   constructor(initReq?: fm.InitReq) {
     this.initReq = initReq;
   }
-  {{- range .Methods}}
+  {{- range .Service.Methods}}
   /**
    * {{functionCase .TSMethodName}} - {{.HTTPMethod}} {{.URL}}
    */
@@ -172,6 +187,39 @@ export class {{.Name}}Client {
   }
   {{- end }}
   {{- end}}
+}
+
+{{end}}
+
+{{define "message_decoder"}}
+type {{.Name}}JSON = {
+{{- range .Fields}}
+{{- if eq .Type "bytes"}}
+{{- if .IsRepeated}}
+  {{tsTypeKey .}}: string[];
+{{- else}}
+  {{tsTypeKey .}}: string;
+{{- end}}
+{{- else}}
+  {{tsTypeKey .}}: {{tsTypeDef .}};
+{{- end}}
+{{- end}}
+};
+
+export function decode{{.Name}}(json: {{.Name}}JSON): {{.Name}} {
+  return {
+{{- range .Fields}}
+{{- if eq .Type "bytes"}}
+{{- if .IsRepeated}}
+    {{fieldName .Name}}: json.{{fieldName .Name}} != null ? json.{{fieldName .Name}}.map((x: string) => fm.b64Decode(x)) : undefined,
+{{- else}}
+    {{fieldName .Name}}: json.{{fieldName .Name}} != null ? fm.b64Decode(json.{{fieldName .Name}}) : undefined,
+{{- end}}
+{{- else}}
+    {{fieldName .Name}}: json.{{fieldName .Name}},
+{{- end}}
+{{- end}}
+  };
 }
 
 {{end}}

--- a/test/integration/defaultConfig/defaultConfig_test.ts
+++ b/test/integration/defaultConfig/defaultConfig_test.ts
@@ -41,15 +41,16 @@ describe("test default configuration", () => {
   it("binary echo", async () => {
     const message = "→ ping";
 
-    const resp: any = await CounterService.EchoBinary(
+    const resp = await CounterService.EchoBinary(
       {
         data: new TextEncoder().encode(message),
       },
       { pathPrefix: "http://localhost:8081" }
     );
 
-    const bytes = b64Decode(resp["data"]);
-    expect(new TextDecoder().decode(bytes)).to.equal(message);
+    // Response data is automatically decoded from base64 to Uint8Array
+    expect(resp.data).to.be.instanceOf(Uint8Array);
+    expect(new TextDecoder().decode(resp.data!)).to.equal(message);
   });
 
   it("binary echo no cast", async () => {
@@ -62,8 +63,9 @@ describe("test default configuration", () => {
       { pathPrefix: "http://localhost:8081" }
     );
 
-    const bytes = b64Decode(resp["data"]);
-    expect(new TextDecoder().decode(bytes)).to.equal(message);
+    // Response data is automatically decoded from base64 to Uint8Array
+    expect(resp.data).to.be.instanceOf(Uint8Array);
+    expect(new TextDecoder().decode(resp.data!)).to.equal(message);
   });
 
   it("http get check request", async () => {


### PR DESCRIPTION
## Problem

TypeScript types declare bytes fields as Uint8Array, but gRPC-Gateway responses contain base64-encoded strings. This type mismatch forces developers to:
- Cast responses to any to avoid type errors
- Manually call b64Decode() on every bytes field
- Lose type safety for response handling

Example broken code:

```
const resp: any = await CounterService.EchoBinary({ data: ... });
const bytes = b64Decode(resp["data"]); // Manual decoding required
```

## Solution

Automatically generate decoder functions for messages containing bytes fields, then chain them in service methods to convert base64 strings to Uint8Array transparently.

Fixed code:

```
const resp = await CounterService.EchoBinary({ data: ... });
// resp.data is already Uint8Array - no manual decoding needed!
expect(resp.data).to.be.instanceOf(Uint8Array);
```

This aligns with the approach outlined in issue #35, keeping Uint8Array types while fixing the runtime decoding automatically.