### PR TITLE
Fix: Wrap bytes fields in URL paths with TextDecoder

### DIFF
--- a/generator/service.ts.tmpl
+++ b/generator/service.ts.tmpl
@@ -126,14 +126,15 @@ export class {{.Service.Name}} {
 {{- range .Service.Methods}}
   /**
    * {{.TSMethodName}} - {{.HTTPMethod}} {{escapeJSDoc .URL}}
+   * Note: Bytes fields in URL paths are automatically decoded to UTF-8 strings.
    */
 {{- if .ServerStreaming }}
   static {{.TSMethodName}}(this:void, req: {{tsType .Input}}, entityNotifier?: fm.NotifyStreamEntityArrival<{{tsType .Output}}>, initReq?: fm.InitReq): Promise<void> {
-    return fm.fetchStreamingRequest<{{tsType .Output}}>(`{{renderURL .}}`, entityNotifier, {...initReq, {{buildInitReq .}}});
+    return fm.fetchStreamingRequest<{{tsType .Output}}>(`{{wrapBytesFieldsInURL . $.Messages}}`, entityNotifier, {...initReq, {{buildInitReq .}}});
   }
 {{- else }}
   static {{.TSMethodName}}(this:void, req: {{tsType .Input}}, initReq?: fm.InitReq): Promise<{{tsType .Output}}> {
-    return fm.fetchRequest<{{tsType .Output}}>(`{{renderURL .}}`, {...initReq, {{buildInitReq .}}})
+    return fm.fetchRequest<{{tsType .Output}}>(`{{wrapBytesFieldsInURL . $.Messages}}`, {...initReq, {{buildInitReq .}}})
     {{- $outputType := tsType .Output -}}
     {{- range $.Messages -}}
       {{- if and .HasBytesFields (eq .Name $outputType) -}}
@@ -151,14 +152,15 @@ export class {{.Service.Name}} {
 {{- range .Service.Methods}}
 /**
  * {{functionCase .TSMethodName}} - {{.HTTPMethod}} {{escapeJSDoc .URL}}
+ * Note: Bytes fields in URL paths are automatically decoded to UTF-8 strings.
  */
 {{- if .ServerStreaming }}
 export function {{functionCase .TSMethodName}}(req: {{tsType .Input}}, entityNotifier?: fm.NotifyStreamEntityArrival<{{tsType .Output}}>, initReq?: fm.InitReq): Promise<void> {
-  return fm.fetchStreamingRequest<{{tsType .Output}}>(`{{renderURL .}}`, entityNotifier, {...initReq, {{buildInitReq .}}});
+  return fm.fetchStreamingRequest<{{tsType .Output}}>(`{{wrapBytesFieldsInURL . $.Messages}}`, entityNotifier, {...initReq, {{buildInitReq .}}});
 }
 {{- else }}
 export function {{functionCase .TSMethodName}}(req: {{tsType .Input}}, initReq?: fm.InitReq): Promise<{{tsType .Output}}> {
-  return fm.fetchRequest<{{tsType .Output}}>(`{{renderURL .}}`, {...initReq, {{buildInitReq .}}})
+  return fm.fetchRequest<{{tsType .Output}}>(`{{wrapBytesFieldsInURL . $.Messages}}`, {...initReq, {{buildInitReq .}}})
   {{- $outputType := tsType .Output -}}
   {{- range $.Messages -}}
     {{- if and .HasBytesFields (eq .Name $outputType) -}}
@@ -176,6 +178,7 @@ export class {{.Service.Name}}Client {
   {{- range .Service.Methods}}
   /**
    * {{functionCase .TSMethodName}} - {{.HTTPMethod}} {{escapeJSDoc .URL}}
+   * Note: Bytes fields in URL paths are automatically decoded to UTF-8 strings.
    */
   {{- if .ServerStreaming }}
   {{functionCase .TSMethodName}}(req: {{tsType .Input}}, entityNotifier?: fm.NotifyStreamEntityArrival<{{tsType .Output}}>, initReq?: fm.InitReq): Promise<void> {

--- a/test/bytes_url_test.go
+++ b/test/bytes_url_test.go
@@ -1,0 +1,89 @@
+package test
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBytesURLGeneration(t *testing.T) {
+	// Generate the TypeScript file first (since .pb.ts files are gitignored)
+	cmd := exec.Command("protoc",
+		"-I", projectRoot+"/test/testdata",
+		"-I", projectRoot+"/test/integration/protos",
+		"--grpc-gateway-ts_out", projectRoot+"/test/testdata",
+		"--grpc-gateway-ts_opt", "logtostderr=true",
+		"bytes_url.proto")
+
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "Failed to generate TypeScript file: %s", string(output))
+
+	// Read the generated TypeScript file
+	content, err := os.ReadFile(projectRoot + "/test/testdata/bytes_url.pb.ts")
+	require.NoError(t, err, "Failed to read generated TypeScript file")
+
+	contentStr := string(content)
+
+	// Verify TextDecoder is used for bytes fields in URLs with null safety
+	t.Run("GetResource method wraps bytes field with TextDecoder and null safety", func(t *testing.T) {
+		assert.Contains(t, contentStr, "req.resourceId ? new TextDecoder().decode(req.resourceId) : ''",
+			"GetResource method should wrap resourceId with TextDecoder and null check")
+	})
+
+	t.Run("LoadArtefact method wraps bytes field with TextDecoder and null safety", func(t *testing.T) {
+		assert.Contains(t, contentStr, "req.encodedArtefactPath ? new TextDecoder().decode(req.encodedArtefactPath) : ''",
+			"LoadArtefact method should wrap encodedArtefactPath with TextDecoder and null check")
+	})
+
+	t.Run("ProcessMultiPath wraps multiple bytes fields with null safety", func(t *testing.T) {
+		assert.Contains(t, contentStr, "req.firstPath ? new TextDecoder().decode(req.firstPath) : ''",
+			"ProcessMultiPath should wrap firstPath with TextDecoder and null check")
+		assert.Contains(t, contentStr, "req.secondPath ? new TextDecoder().decode(req.secondPath) : ''",
+			"ProcessMultiPath should wrap secondPath with TextDecoder and null check")
+	})
+
+	t.Run("Non-bytes fields are not wrapped", func(t *testing.T) {
+		// The parent field in LoadArtefact is a string, should not be wrapped
+		lines := strings.Split(contentStr, "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "LoadArtefact") && strings.Contains(line, "fetchRequest") {
+				assert.Contains(t, line, "${req.parent}",
+					"Non-bytes field 'parent' should not be wrapped with TextDecoder")
+				assert.NotContains(t, line, "TextDecoder().decode(req.parent)",
+					"Non-bytes field 'parent' should not be wrapped with TextDecoder")
+				break
+			}
+		}
+	})
+
+	t.Run("JSDoc notes about UTF-8 decoding are present", func(t *testing.T) {
+		assert.Contains(t, contentStr, "Note: Bytes fields in URL paths are automatically decoded to UTF-8 strings.",
+			"JSDoc should mention automatic UTF-8 decoding")
+
+		// Count occurrences - should be present for each method
+		count := strings.Count(contentStr, "Note: Bytes fields in URL paths are automatically decoded to UTF-8 strings.")
+		assert.Equal(t, 3, count, "JSDoc note should appear for all 3 methods")
+	})
+
+	t.Run("TypeScript types are correct", func(t *testing.T) {
+		// Verify that request types have Uint8Array for bytes fields
+		assert.Contains(t, contentStr, "resourceId?: Uint8Array",
+			"GetResourceRequest should have resourceId as Uint8Array")
+		assert.Contains(t, contentStr, "encodedArtefactPath?: Uint8Array",
+			"LoadArtefactRequest should have encodedArtefactPath as Uint8Array")
+		assert.Contains(t, contentStr, "firstPath?: Uint8Array",
+			"MultiFieldRequest should have firstPath as Uint8Array")
+		assert.Contains(t, contentStr, "secondPath?: Uint8Array",
+			"MultiFieldRequest should have secondPath as Uint8Array")
+	})
+}
+
+func TestBytesURLTypeScriptCompiles(t *testing.T) {
+	result := runTsc()
+	assert.Equal(t, 0, result.exitCode, "TypeScript compilation should succeed. Output:\n%s\n%s",
+		result.stdout, result.stderr)
+}

--- a/test/testdata/bytes_url.proto
+++ b/test/testdata/bytes_url.proto
@@ -1,0 +1,58 @@
+syntax = 'proto3';
+
+package test.bytesurl;
+
+import "google/api/annotations.proto";
+
+message LoadArtefactRequest {
+  string parent = 1;
+  bytes encoded_artefact_path = 2;
+}
+
+message LoadArtefactResponse {
+  string content = 1;
+  bytes data = 2;
+}
+
+message GetResourceRequest {
+  bytes resource_id = 1;
+}
+
+message GetResourceResponse {
+  string name = 1;
+  bytes content = 2;
+}
+
+message MultiFieldRequest {
+  string project = 1;
+  bytes first_path = 2;
+  string environment = 3;
+  bytes second_path = 4;
+}
+
+message MultiFieldResponse {
+  bool success = 1;
+}
+
+service BytesURLService {
+  // Test single bytes field in URL path
+  rpc GetResource(GetResourceRequest) returns (GetResourceResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/resources/{resource_id}"
+    };
+  }
+
+  // Test bytes field with wildcard pattern
+  rpc LoadArtefact(LoadArtefactRequest) returns (LoadArtefactResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/{parent=projects/*/bundles/*}/artefacts/{encoded_artefact_path=**}"
+    };
+  }
+
+  // Test multiple bytes fields in URL path
+  rpc ProcessMultiPath(MultiFieldRequest) returns (MultiFieldResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/{project}/paths/{first_path}/env/{environment}/items/{second_path}"
+    };
+  }
+}


### PR DESCRIPTION
Follow-on from #40 for an edge case:

When bytes fields are used in URL path parameters, Uint8Array values were being interpolated directly into template strings, producing malformed URLs like "/api/v1/resource/104,101,108,108,111" instead of "/api/v1/resource/hello".

This commit adds automatic UTF-8 decoding for bytes fields in URL paths using TextDecoder, with null safety for optional fields:

- Add wrapBytesFieldsInURL() template function in generator/template.go
- Update service.ts.tmpl to wrap bytes fields with TextDecoder
- Add unit and integration tests
- Add JSDoc notes documenting automatic UTF-8 decoding