### PR TITLE
Bug: HTTP Request Body Uses snake_case Instead of camelCase Field Names

### DIFF
--- a/test/custom_body_test.go
+++ b/test/custom_body_test.go
@@ -1,0 +1,63 @@
+package test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomBodyFieldNaming(t *testing.T) {
+	// Generate the TypeScript file first (since .pb.ts files are gitignored)
+	cmd := exec.Command("protoc",
+		"-I", projectRoot+"/test/testdata",
+		"-I", projectRoot+"/test/integration/protos",
+		"--grpc-gateway-ts_out", projectRoot+"/test/testdata",
+		"--grpc-gateway-ts_opt", "logtostderr=true",
+		"custom_body.proto")
+
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "Failed to generate TypeScript file: %s", string(output))
+
+	// Read the generated TypeScript file
+	content, err := os.ReadFile(projectRoot + "/test/testdata/custom_body.pb.ts")
+	require.NoError(t, err, "Failed to read generated TypeScript file")
+
+	contentStr := string(content)
+
+	t.Run("UpdateUser uses camelCase field name for custom body", func(t *testing.T) {
+		// Should use req["userUpdate"] not req["user_update"]
+		assert.Contains(t, contentStr, `req["userUpdate"]`,
+			"UpdateUser should use camelCase field name 'userUpdate'")
+		assert.NotContains(t, contentStr, `req["user_update"]`,
+			"UpdateUser should not use snake_case field name 'user_update'")
+	})
+
+	t.Run("CreatePost uses camelCase field name for custom body", func(t *testing.T) {
+		// Should use req["postContent"] not req["post_content"]
+		assert.Contains(t, contentStr, `req["postContent"]`,
+			"CreatePost should use camelCase field name 'postContent'")
+		assert.NotContains(t, contentStr, `req["post_content"]`,
+			"CreatePost should not use snake_case field name 'post_content'")
+	})
+
+	t.Run("TypeScript types are correct", func(t *testing.T) {
+		// Verify that request types have camelCase for fields
+		assert.Contains(t, contentStr, "userId?: string",
+			"UpdateUserRequest should have userId as string")
+		assert.Contains(t, contentStr, "userUpdate?: UserUpdate",
+			"UpdateUserRequest should have userUpdate as UserUpdate")
+		assert.Contains(t, contentStr, "authorId?: string",
+			"CreatePostRequest should have authorId as string")
+		assert.Contains(t, contentStr, "postContent?: PostContent",
+			"CreatePostRequest should have postContent as PostContent")
+	})
+}
+
+func TestCustomBodyTypeScriptCompiles(t *testing.T) {
+	result := runTsc()
+	assert.Equal(t, 0, result.exitCode, "TypeScript compilation should succeed. Output:\n%s\n%s",
+		result.stdout, result.stderr)
+}

--- a/test/testdata/custom_body.proto
+++ b/test/testdata/custom_body.proto
@@ -1,0 +1,55 @@
+syntax = 'proto3';
+
+package test.custombody;
+
+import "google/api/annotations.proto";
+
+message UserUpdate {
+  string display_name = 1;
+  string email = 2;
+}
+
+message UpdateUserRequest {
+  string user_id = 1;
+  UserUpdate user_update = 2;
+}
+
+message UserResponse {
+  string user_id = 1;
+  string display_name = 2;
+  string email = 3;
+}
+
+message CreatePostRequest {
+  string author_id = 1;
+  PostContent post_content = 2;
+}
+
+message PostContent {
+  string title = 1;
+  string body = 2;
+}
+
+message PostResponse {
+  string post_id = 1;
+  string author_id = 2;
+  string title = 3;
+}
+
+service CustomBodyService {
+  // Test custom body field with snake_case name
+  rpc UpdateUser(UpdateUserRequest) returns (UserResponse) {
+    option (google.api.http) = {
+      patch: "/api/v1/users/{user_id}"
+      body: "user_update"
+    };
+  }
+
+  // Test custom body field with snake_case name
+  rpc CreatePost(CreatePostRequest) returns (PostResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/posts"
+      body: "post_content"
+    };
+  }
+}


### PR DESCRIPTION
## Summary

When a gRPC method has a custom HTTP request body field (using body: "field_name" in the google.api.http annotation), the generated TypeScript code would always use the proto's snake_case field name instead of the camelCase field name that matches the TypeScript interface, causing runtime errors and/or undefined values being sent to the backend.

###  Example

```proto
Proto definition:
message UpdateUserRequest {
  string user_id = 1;
  UserUpdate user_update = 2;
}

service UserService {
  rpc UpdateUser(UpdateUserRequest) returns (UserResponse) {
    option (google.api.http) = {
      patch: "/v1/users/{user_id}"
      body: "user_update"
    };
  }
}
```

Current (incorrect) generated code:

```ts
export type UpdateUserRequest = {
  userId?: string;
  userUpdate?: UserUpdate;  // ✅ Interface uses camelCase
};

static UpdateUser(req: UpdateUserRequest, initReq?: fm.InitReq): Promise<UserResponse> {
  return fm.fetchRequest<UserResponse>(
    `/v1/users/${req.userId}`,
    {method: "PATCH", body: JSON.stringify(req["user_update"], fm.replacer)}  // ❌ Accesses snake_case
  );
}
```

This fails because `req["user_update"]` is undefined (the property is actually `userUpdate`).

##  Root Cause

The buildInitReq() function in generator/template.go uses the raw proto field name from *method.HTTPRequestBody without converting it to camelCase using the fieldName() helper.

## Fix

Update buildInitReq() to accept a *registry.Registry parameter and use the fieldName() helper to convert field names, matching how URL path parameters are already handled. This now respects the UseProtoNames option for HTTP request bodies
